### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ adamw_params.extend(model.head.parameters())
 adamw_params.extend(model.embed.parameters())
 # Create the optimizer
 optimizer = Muon(muon_params, lr=0.02, momentum=0.95,
-                 adamw_params=adaw_params, adamw_lr=3e-4, adamw_betas=(0.90, 0.95), adamw_wd=0.01)
+                 adamw_params=adamw_params, adamw_lr=3e-4, adamw_betas=(0.90, 0.95), adamw_wd=0.01)
 ```
 
 You'll have to replace `model.body`, `model.head`, and `model.embed` with whatever subset is appropriate for your model.


### PR DESCRIPTION
an `m` was dropped in the example (found when I copy pasted this in to my training script)