### PR TITLE
Optimize Newton-Schulz Iteration in `zeropower_via_newtonschulz5` Function

### DIFF
--- a/muon.py
+++ b/muon.py
@@ -15,8 +15,7 @@ def zeropower_via_newtonschulz5(G, steps=10, eps=1e-7):
     """
     assert len(G.shape) == 2
     a, b, c = (3.4445, -4.7750, 2.0315)
-    # X = G.bfloat16()
-    X = G.float()
+    X = G.bfloat16()
     X /= (X.norm() + eps)
     if G.size(0) > G.size(1):
         X = X.T

--- a/muon.py
+++ b/muon.py
@@ -14,15 +14,17 @@ def zeropower_via_newtonschulz5(G, steps=10, eps=1e-7):
     performance at all relative to UV^T, where USV^T = G is the SVD.
     """
     assert len(G.shape) == 2
-    a, b, c = (3.4445, -4.7750,  2.0315)
-    X = G.bfloat16()
-    X /= (X.norm() + eps) # ensure top singular value <= 1
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    # X = G.bfloat16()
+    X = G.float()
+    X /= (X.norm() + eps)
     if G.size(0) > G.size(1):
         X = X.T
     for _ in range(steps):
         A = X @ X.T
-        B = b * A + c * A @ A
-        X = a * X + B @ X
+        Y = A @ X
+        Z = A @ Y
+        X = a * X + b * Y + c * Z
     if G.size(0) > G.size(1):
         X = X.T
     return X

--- a/muon.py
+++ b/muon.py
@@ -16,7 +16,7 @@ def zeropower_via_newtonschulz5(G, steps=10, eps=1e-7):
     assert len(G.shape) == 2
     a, b, c = (3.4445, -4.7750, 2.0315)
     X = G.bfloat16()
-    X /= (X.norm() + eps)
+    X /= (X.norm() + eps) # ensure top singular value <= 1
     if G.size(0) > G.size(1):
         X = X.T
     for _ in range(steps):


### PR DESCRIPTION
This pull request introduces a minor optimization to the `zeropower_via_newtonschulz5` function, improving its computational efficiency while preserving the original functionality. The changes involve reworking the Newton-Schulz iteration to simplify the matrix operations and reduce redundant computations.

**Summary of Changes**

Replaced `B @ X` with direct computation of intermediate matrices `Y = A @ X` and `Z = A @ Y` to reduce redundant matrix multiplications.

**Testing and Validation**

It produces results consistent with the original implementation and shows a noticeable reduction in execution time across some general test cases.

```
Testing matrix 1/28 with shape torch.Size([128, 128])
Time Original: 0.001342s, Time Optimized: 0.002916s, Max Difference: 1.953125e-02
Testing matrix 2/28 with shape torch.Size([256, 256])
Time Original: 0.001459s, Time Optimized: 0.000771s, Max Difference: 1.519775e-02
Testing matrix 3/28 with shape torch.Size([512, 512])
Time Original: 0.001191s, Time Optimized: 0.000745s, Max Difference: 1.269531e-02
Testing matrix 4/28 with shape torch.Size([1024, 1024])
Time Original: 0.001138s, Time Optimized: 0.000705s, Max Difference: 9.765625e-03
Testing matrix 5/28 with shape torch.Size([2048, 2048])
Time Original: 0.001234s, Time Optimized: 0.000813s, Max Difference: 7.324219e-03
Testing matrix 6/28 with shape torch.Size([4096, 4096])
Time Original: 0.001258s, Time Optimized: 0.000731s, Max Difference: 5.615234e-03
Testing matrix 7/28 with shape torch.Size([8192, 8192])
Time Original: 0.001405s, Time Optimized: 0.000822s, Max Difference: 4.272461e-03
Testing matrix 8/28 with shape torch.Size([16384, 16384])
Time Original: 0.001457s, Time Optimized: 0.000766s, Max Difference: 2.929688e-03
Testing matrix 9/28 with shape torch.Size([32768, 32768])
Time Original: 0.001786s, Time Optimized: 0.001133s, Max Difference: 2.075195e-03
Testing matrix 10/28 with shape torch.Size([128, 256])
Time Original: 0.003732s, Time Optimized: 0.001624s, Max Difference: 1.953125e-02
Testing matrix 11/28 with shape torch.Size([256, 512])
Time Original: 0.002081s, Time Optimized: 0.001319s, Max Difference: 1.464844e-02
Testing matrix 12/28 with shape torch.Size([512, 1024])
Time Original: 0.002101s, Time Optimized: 0.001302s, Max Difference: 1.123047e-02
Testing matrix 13/28 with shape torch.Size([1024, 2048])
Time Original: 0.002105s, Time Optimized: 0.001343s, Max Difference: 8.789062e-03
Testing matrix 14/28 with shape torch.Size([2048, 4096])
Time Original: 0.002107s, Time Optimized: 0.001300s, Max Difference: 5.859375e-03
Testing matrix 15/28 with shape torch.Size([4096, 8192])
Time Original: 0.002411s, Time Optimized: 0.001329s, Max Difference: 5.126953e-03
Testing matrix 16/28 with shape torch.Size([8192, 16384])
Time Original: 0.002453s, Time Optimized: 0.001370s, Max Difference: 2.929688e-03
Testing matrix 17/28 with shape torch.Size([16384, 32768])
Time Original: 0.002493s, Time Optimized: 0.001388s, Max Difference: 2.807617e-03
Testing matrix 18/28 with shape torch.Size([128, 512])
Time Original: 0.003081s, Time Optimized: 0.001490s, Max Difference: 1.367188e-02
Testing matrix 19/28 with shape torch.Size([256, 1024])
Time Original: 0.002102s, Time Optimized: 0.001289s, Max Difference: 1.171875e-02
Testing matrix 20/28 with shape torch.Size([512, 2048])
Time Original: 0.002274s, Time Optimized: 0.001295s, Max Difference: 1.025391e-02
Testing matrix 21/28 with shape torch.Size([1024, 4096])
Time Original: 0.002175s, Time Optimized: 0.001415s, Max Difference: 6.103516e-03
Testing matrix 22/28 with shape torch.Size([2048, 8192])
Time Original: 0.002268s, Time Optimized: 0.001378s, Max Difference: 4.638672e-03
Testing matrix 23/28 with shape torch.Size([128, 1024])
Time Original: 0.002245s, Time Optimized: 0.001336s, Max Difference: 9.765625e-03
Testing matrix 24/28 with shape torch.Size([256, 2048])
Time Original: 0.002122s, Time Optimized: 0.001374s, Max Difference: 1.025391e-02
Testing matrix 25/28 with shape torch.Size([512, 4096])
Time Original: 0.002066s, Time Optimized: 0.001325s, Max Difference: 6.835938e-03
Testing matrix 26/28 with shape torch.Size([1024, 8192])
Time Original: 0.002187s, Time Optimized: 0.001423s, Max Difference: 4.028320e-03
Testing matrix 27/28 with shape torch.Size([2048, 16384])
Time Original: 0.002298s, Time Optimized: 0.001348s, Max Difference: 4.150391e-03
Testing matrix 28/28 with shape torch.Size([4096, 32768])
Time Original: 0.002350s, Time Optimized: 0.001332s, Max Difference: 3.295898e-03
```