### PR TITLE
Ignore zero-grad tensors and return the loss from the closure.

### DIFF
--- a/muon.py
+++ b/muon.py
@@ -113,6 +113,8 @@ class Muon(torch.optim.Optimizer):
                 # luckily this will perfectly distribute a transformer with multiple of 4 layers to 8 GPUs
                 if i % self.world_size == self.rank:
                     g = p.grad
+                    if g is None:
+                        continue
                     if g.ndim > 2:
                         g = g.view(g.size(0), -1)
                     assert g is not None
@@ -153,7 +155,8 @@ class Muon(torch.optim.Optimizer):
 
             for p in params:
                 g = p.grad
-                assert g is not None
+                if g is None:
+                    continue
                 state = self.state[p]
                 if 'step' not in state:
                     state['step'] = 0
@@ -174,3 +177,4 @@ class Muon(torch.optim.Optimizer):
                 p.data.mul_(1 - lr * weight_decay)
                 p.data.add_(g, alpha=-lr/scale)
 
+        return loss


### PR DESCRIPTION
If the tensor doesn't contribute to the loss but is still in the param list, we should ignore it. 

> I'm not sure if we should ignore it or raise an exception. I'm still trying to understand the algorithm.

Also, the loss from closure should be returned by the `step` function.

---

I also tried using Muon Optimizer with PINNs, and [here](https://github.com/Adversarr/PINNs-optimizer-bench) are my results. Muon is clearly better than the commonly used Adam optimizer in that case.