### PR TITLE
Auto-classify params into Muon or internal AdamW

### DIFF
--- a/muon.py
+++ b/muon.py
@@ -1,6 +1,7 @@
 import os
 import torch
 import torch.distributed as dist
+from typing import Optional, List, Tuple
 from torch import Tensor
 
 def zeropower_via_newtonschulz5(G: Tensor, steps: int) -> Tensor:
@@ -47,19 +48,60 @@ class Muon(torch.optim.Optimizer):
     or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
     - To use it with 4D convolutional filters, it works well to just flatten their last 3 dimensions.
 
+    Muon runs an internal AdamW for any parameters that are marked adamw_params. If you don't specify
+    muon_params or adamw_params, you can pass the model itself and Muon will auto-classify parameters.
+    Passing the model to an optimizer isn't standard PyTorch philosophy, but Muon is an architecture-
+    aware optimizer that treats linear weight parameters differently from embedding or bias parameters.
+    For more on the architecture-aware approach: https://arxiv.org/abs/2410.21265
+
+    Example usages:
+    >>> # Auto-classify all the model's parameters into Muon and AdamW (default)
+    >>> muon = Muon(params=model.parameters(), model=model)
+    >>> # Auto-classify and optimize over specific parameters only
+    >>> muon = Muon(params=params_sublist, model=model)
+    >>> # Specify explicitly which should use Muon and AdamW
+    >>> muon = Muon(muon_params=linear_params, adamw_params=embedding_and_head_params)
+    >>> # Use two optimizers (warns you not to put embedding/head params in Muon)
+    >>> muon, adamw = Muon(muon_params=muon_params), AdamW(params=adamw_params)
+
+    Common mistake:
+    >>> # This will perform poorly on the embedding/head params
+    >>> muon = Muon(muon_params=model.parameters())
+
     Arguments:
+        params: The parameters to optimize, auto-classified to use Muon or the internal AdamW.
+        model: The PyTorch model, required if auto-classifying parameters into Muon and AdamW.
+        muon_params: Overrides auto-classification and specifies which parameters should use Muon.
+        adamw_params: Overrides auto-classification and specifies which parameters should use AdamW.
+                      Any params in `muon_params` that are {0, 1}-D will be optimized by AdamW as well.
+        suppress_warning: Don't warn about a common mistake (using Muon on embedding/output params)
         lr: The learning rate used by the internal SGD.
         momentum: The momentum used by the internal SGD.
         nesterov: Whether to use Nesterov-style momentum in the internal SGD. (recommended)
         ns_steps: The number of Newton-Schulz iteration steps to use.
+        weight_decay: The weight decay for Muon parameters.
+        adamw_lr: The learning rate for the internal AdamW.
+        adamw_betas: The betas for the internal AdamW.
+        adamw_eps: The epsilon for the internal AdamW.
+        adamw_wd: The weight decay for the internal AdamW.
+        rank: The rank of the current GPU.    (use rank=0 for single GPU)
+        world_size: The total number of GPUs. (use world_size=1 for single GPU)
     """
-    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, nesterov=True, ns_steps=5, rank=None, world_size=None):
+    def __init__(self, params=None, model=None, muon_params=None, adamw_params=None, suppress_warning=False,
+                 lr=0.02, momentum=0.95, nesterov=True, ns_steps=5, weight_decay=0.01,
+                 adamw_lr=3e-4, adamw_betas=(0.95, 0.95), adamw_eps=1e-12, adamw_wd=0,
+                 rank=None, world_size=None):
         if (rank is None) or (world_size is None):
             raise Exception("world_size and rank params required, if you want to use this optimizer on a single GPU, pass rank=0 and world_size=1.")
         self.rank = rank
         self.world_size = world_size
-        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, nesterov=nesterov, ns_steps=ns_steps)
-        params: list[Tensor] = [*params]
+        defaults = dict(lr=lr, momentum=momentum, nesterov=nesterov, ns_steps=ns_steps, weight_decay=weight_decay,
+                        adamw_lr_ratio=adamw_lr/lr, adamw_betas=adamw_betas, adamw_eps=adamw_eps, adamw_wd=adamw_wd)
+        muon_params, adamw_params = get_muon_and_adamw_params(
+            model=model, params=params, muon_params=muon_params, adamw_params=adamw_params, suppress_warning=suppress_warning
+        )
+        params: list[Tensor] = [*muon_params, *adamw_params]
+            
         param_groups = []
         for size in {p.numel() for p in params}:
             b = torch.empty(world_size, size, dtype=torch.bfloat16, device="cuda")
@@ -68,13 +110,23 @@ class Muon(torch.optim.Optimizer):
             param_groups.append(group)
         super().__init__(param_groups, defaults)
 
+        # Mark parameters as Muon or AdamW
+        muon_param_ids = {id(p) for p in muon_params}
+        for param_group in self.param_groups:
+            for p in param_group['params']:
+                self.state[p]['use_muon'] = id(p) in muon_param_ids and p.ndim > 1
+
     @torch.no_grad()
     def step(self):
         for group in self.param_groups:
+            ############################
+            #           Muon           #
+            ############################
+            
+            params = [p for p in group['params'] if self.state[p]['use_muon']]
+            # generate weight updates in distributed fashion
             update_buffer: Tensor = group["update_buffer"]
             update_buffer_views: list[Tensor] = group["update_buffer_views"]
-            # generate weight updates in distributed fashion
-            params: list[Tensor] = group["params"]
             handle = None
             params_world = None
             def update_prev(): # optimized Muon implementation contributed by @YouJiacheng
@@ -104,3 +156,96 @@ class Muon(torch.optim.Optimizer):
                 handle = dist.all_gather_into_tensor(update_buffer, g, async_op=True)
                 params_world = params[base_i : base_i + self.world_size]
             update_prev()
+            
+            ############################
+            #       AdamW backup       #
+            ############################
+            
+            params = [p for p in group['params'] if not self.state[p]['use_muon']]
+            lr = group['adamw_lr_ratio'] * group['lr'] # in order for lr schedule to work
+            beta1, beta2 = group['adamw_betas']
+            eps = group['adamw_eps']
+            weight_decay = group['adamw_wd']
+            
+            for p in params:
+                g = p.grad
+                if g is None:
+                    continue
+                state = self.state[p]
+                if 'step' not in state:
+                    state['step'] = 0
+                    state['moment1'] = torch.zeros_like(g)
+                    state['moment2'] = torch.zeros_like(g)
+                state['step'] += 1
+                step = state['step']
+                buf1 = state['moment1']
+                buf2 = state['moment2']
+                buf1.lerp_(g, 1-beta1)
+                buf2.lerp_(g.square(), 1-beta2)
+                
+                g = buf1 / (eps + buf2.sqrt())
+                
+                bias_correction1 = 1 - beta1**step
+                bias_correction2 = 1 - beta2**step
+                scale = bias_correction1 / bias_correction2**0.5
+                p.data.mul_(1 - lr * weight_decay)
+                p.data.add_(g, alpha=-lr/scale)
+
+def get_muon_and_adamw_params(
+    model: Optional[torch.nn.Module] = None,
+    params: Optional[List[torch.nn.Parameter]] = None,
+    muon_params: Optional[List[torch.nn.Parameter]] = None,
+    adamw_params: Optional[List[torch.nn.Parameter]] = None,
+    suppress_warning: bool = False,
+) -> Tuple[List[torch.nn.Parameter], List[torch.nn.Parameter]]:
+    """
+    Auto-classifies parameters into two groups:
+    1. Linear/conv weight parameters (for Muon)
+    2. Bias, embedding, and other (for AdamW)
+
+    To directly specify, pass muon_params and adamw_params, and do not set model or params.
+
+    Arguments:
+        model: full model required if auto-classifying parameters (default)
+        params: specific parameters to auto-classify into either Muon or AdamW
+        muon_params: overrides auto-classification and specifies which parameters should use Muon
+        adamw_params: overrides auto-classification and specifies which parameters should use AdamW
+        suppress_warning: don't warn about a common mistake (using Muon on embedding/output params)
+    """
+    assert (model is None and params is None) or (muon_params is None and adamw_params is None), (
+        "Cannot mix auto-classifying (params/model) with explicit parameter grouping (muon_params/adamw_params). For manual control, do not pass model or params."
+    )
+    if muon_params is not None and adamw_params is not None:
+        return muon_params, adamw_params
+    elif muon_params is not None:
+        if not suppress_warning:
+            print(
+                "Warning: you are optimizing all parameters with Muon, but did you mean to use the default optimizer "
+                "AdamW for bias or embedding parameters? To ignore this message, you can set suppress_warning=True."
+            )
+        return muon_params, []
+    elif adamw_params is not None:
+        return [], adamw_params
+    elif model is not None:
+        # Auto-classify into Muon or AdamW based on whether a param is a hidden layer parameter
+        params = params if params is not None else list(model.parameters())
+        embedding_ids = {id(m.weight) for m in model.modules() if isinstance(m, torch.nn.Embedding)}
+        def muon_criterion(module, param):
+            return (
+                param.ndim > 1 and
+                id(param) not in embedding_ids and  # prevents misclassifying tied embedding weights
+                isinstance(module, (torch.nn.Linear, torch.nn.Conv1d, torch.nn.Conv2d, torch.nn.Conv3d))
+            )
+        muon_param_ids = set()
+        for module in model.modules():
+            for param in module.parameters(recurse=False):
+                if muon_criterion(module, param):
+                    muon_param_ids.add(id(param))
+        muon_params = [p for p in params if id(p) in muon_param_ids]
+        adamw_params = [p for p in params if id(p) not in muon_param_ids]
+        return muon_params, adamw_params
+    else:
+        raise Exception(
+            "To auto-classify params to use Muon or its built-in AdamW, you need to pass the model like Muon(..., model=model). "
+            "If you want direct control over which params use Muon or AdamW, pass muon_params and adamw_params instead."
+        )

--- a/test.py
+++ b/test.py
@@ -1,0 +1,302 @@
+import torch
+import muon
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.distributed as dist
+from contextlib import contextmanager, redirect_stdout
+import io
+import os
+
+################################################################ 
+# Define PyTorch modules to test: MLP, CNN, GPT, TiedEmbedding #
+################################################################ 
+
+class MLP(nn.Module):
+    def __init__(self, width):
+        super().__init__()
+        self.fc1 = nn.Linear(width, 4*width)
+        self.fc2 = nn.Linear(4*width, width)
+        self.relu = nn.ReLU()
+
+class CNN(nn.Module):
+    def __init__(self, width):
+        super().__init__()
+        self.conv1 = nn.Conv2d(width, width, 3, padding=1)
+        self.conv2 = nn.Conv2d(width, width, 3, padding=1)
+        self.batchnorm = nn.BatchNorm2d(width)
+        self.final_layer = nn.Linear(width, width)
+        self.relu = nn.ReLU()
+
+class Attention(nn.Module):
+    def __init__(self, embed_dim, dropout=0.0):
+        super().__init__()
+        
+        self.q_proj = nn.Linear(embed_dim, embed_dim)
+        self.k_proj = nn.Linear(embed_dim, embed_dim)
+        self.v_proj = nn.Linear(embed_dim, embed_dim)
+        self.out_proj = nn.Linear(embed_dim, embed_dim)
+
+        self.q_norm = nn.LayerNorm(embed_dim)
+        self.k_norm = nn.LayerNorm(embed_dim)
+
+class Block(nn.Module):
+    def __init__(self, width):
+        super().__init__()
+        self.mlp = MLP(width)
+        self.attention = Attention(width)
+        self.norm1 = nn.LayerNorm(width)
+        self.norm2 = nn.LayerNorm(width)
+        
+class GPT(nn.Module):
+    def __init__(self, width, num_layers):
+        super().__init__()
+        self.embedding = nn.Embedding(width, width)
+        self.transformer = nn.ModuleList([Block(width) for _ in range(num_layers)])
+        self.ln = nn.LayerNorm(width)
+        self.lm_head = nn.Linear(width, width)
+
+class TiedEmbedding(nn.Module):
+    def __init__(self, width):
+        super().__init__()
+        self.embedding = nn.Embedding(width, width)
+        self.lm_head = nn.Linear(width, width)
+        self.lm_head.weight = self.embedding.weight
+        
+#############################################################
+# Test cases for auto-classifying Muon vs. AdamW parameters #
+#############################################################
+
+def test_mlp():
+    model = MLP(width=2)
+    muon_params, adamw_params = muon.get_muon_and_adamw_params(model=model)
+
+    # check that muon_params contains the fc1 and fc2 parameters
+    muon_expected = {id(model.fc1.weight), id(model.fc2.weight)}
+    muon_actual = {id(p) for p in muon_params}
+    if not muon_expected.issubset(muon_actual):
+        print("Not all weight parameters are in muon_params")
+        return False
+    elif len(muon_actual - muon_expected) > 0:
+        print("muon_params contains unknown extra parameters")
+        return False
+
+    # check that adamw_params contains only bias parameters
+    adamw_expected = {id(model.fc1.bias), id(model.fc2.bias)}
+    adamw_actual = {id(p) for p in adamw_params}
+    if not adamw_expected.issubset(adamw_actual):
+        print("Not all bias parameters are in adamw_params")
+        return False
+    elif len(adamw_actual - adamw_expected) > 0:
+        print("adamw_params contains unknown extra parameters")
+        return False
+
+    return True
+
+def test_cnn():
+    model = CNN(width=2)
+    muon_params, adamw_params = muon.get_muon_and_adamw_params(model=model)
+    
+    # check that muon_params contains the conv1, conv2, and final_layer parameters
+    muon_expected = {id(model.conv1.weight), id(model.conv2.weight), id(model.final_layer.weight)}
+    muon_actual = {id(p) for p in muon_params}
+    if not muon_expected.issubset(muon_actual):
+        print("Not all weight parameters are in muon_params")
+        return False
+    elif len(muon_actual - muon_expected) > 0:
+        print("muon_params contains unknown extra parameters")
+        return False
+    
+    # check that adamw_params contains the conv1, conv2, and final_layer biases, and batchnorm parameters
+    adamw_expected = {id(model.conv1.bias), id(model.conv2.bias), id(model.final_layer.bias), id(model.batchnorm.weight), id(model.batchnorm.bias)}
+    adamw_actual = {id(p) for p in adamw_params}
+    if not adamw_expected.issubset(adamw_actual):
+        print("Not all weight parameters are in adamw_params")
+        return False
+    elif len(adamw_actual - adamw_expected) > 0:
+        print("adamw_params contains unknown extra parameters")
+        return False
+
+    return True
+
+def test_gpt():
+    model = GPT(width=2, num_layers=1)
+    muon_params, adamw_params = muon.get_muon_and_adamw_params(model=model)
+    
+    # Check that muon_params contains weight parameters from all linear layers
+    muon_expected = {
+        id(model.transformer[0].attention.q_proj.weight),
+        id(model.transformer[0].attention.k_proj.weight),
+        id(model.transformer[0].attention.v_proj.weight), 
+        id(model.transformer[0].attention.out_proj.weight),
+        id(model.transformer[0].mlp.fc1.weight),
+        id(model.transformer[0].mlp.fc2.weight),
+        id(model.lm_head.weight),
+    }
+    muon_actual = {id(p) for p in muon_params}
+    if not muon_expected.issubset(muon_actual):
+        print("Not all weight parameters are in muon_params")
+        return False
+    elif len(muon_actual - muon_expected) > 0:
+        print("muon_params contains unknown extra parameters")
+        return False
+    
+    # Check that adamw_params contains the embedding weight, bias parameters, and normalization layers
+    adamw_expected = {
+        id(model.embedding.weight),
+        id(model.lm_head.bias),
+        id(model.ln.weight),
+        id(model.ln.bias),
+        id(model.transformer[0].mlp.fc1.bias),
+        id(model.transformer[0].mlp.fc2.bias),
+        id(model.transformer[0].attention.q_norm.weight),
+        id(model.transformer[0].attention.q_norm.bias),
+        id(model.transformer[0].attention.k_norm.weight),
+        id(model.transformer[0].attention.k_norm.bias),
+        id(model.transformer[0].attention.q_proj.bias),
+        id(model.transformer[0].attention.k_proj.bias),
+        id(model.transformer[0].attention.v_proj.bias),
+        id(model.transformer[0].attention.out_proj.bias),
+        id(model.transformer[0].norm1.weight),
+        id(model.transformer[0].norm1.bias),
+        id(model.transformer[0].norm2.weight),
+        id(model.transformer[0].norm2.bias),
+    }
+    adamw_actual = {id(p) for p in adamw_params}
+    if not adamw_expected.issubset(adamw_actual):
+        print("Not all bias, embedding, or normalization parameters are in adamw_params")
+        return False
+    elif len(adamw_actual - adamw_expected) > 0:
+        print("adamw_params contains unknown extra parameters")
+        return False
+    
+    return True
+
+def test_tied_embedding():
+    model = TiedEmbedding(width=2)
+    muon_params, adamw_params = muon.get_muon_and_adamw_params(model=model)
+    
+    # Check that muon_params does not contain the weight from Linear -- because it is shared with the embedding
+    muon_actual = {id(p) for p in muon_params}
+    if len(muon_actual) > 0:
+        print("Linear weight detected in muon_params even though it is tied to the embedding")
+        return False
+    
+    # Check that adamw_params contains the embedding weight and lm_head bias
+    adamw_expected = {id(model.embedding.weight), id(model.lm_head.bias)}
+    adamw_actual = {id(p) for p in adamw_params}
+    if not adamw_expected.issubset(adamw_actual):
+        print("Embedding weight not detected for adamw_params")
+        return False
+    elif len(adamw_actual - adamw_expected) > 0:
+        print("adamw_params contains unknown extra parameters")
+        return False
+    
+    return True
+
+def test_error_messages():
+    model = MLP(width=2)
+    muon_params = [model.fc1.weight, model.fc2.weight]
+    adamw_params = [model.fc1.weight, model.fc2.bias]
+    try:
+        muon.get_muon_and_adamw_params(muon_params=muon_params, adamw_params=adamw_params)
+    except Exception as e:
+        print(f"Threw error when passing muon_params and adamw_params correctly")
+        return False
+    
+    try:
+        muon.get_muon_and_adamw_params(model=model)
+    except Exception as e:
+        print("Threw error when passing model correctly")
+        return False
+    
+    try:
+        muon.get_muon_and_adamw_params(model=model, muon_params=muon_params)
+    except Exception as e:
+        pass
+    else:
+        print("Did not throw error when passing model and muon_params")
+        return False
+    
+    try:
+        muon.get_muon_and_adamw_params(model=model, params=model.parameters(), adamw_params=adamw_params)
+    except Exception as e:
+        pass
+    else:
+        print("Did not throw error when passing model, params, and adamw_params")
+        return False
+    
+    try:
+        muon.get_muon_and_adamw_params(params=model.parameters())
+    except Exception as e:
+        pass
+    else:
+        print("Did not throw error when passing params without model")
+        return False
+    
+    # Test that passing only muon_params prints a warning, and that suppress_warning works
+    @contextmanager
+    def capture_stdout():
+        f = io.StringIO()
+        with redirect_stdout(f):
+            yield f
+    
+    with capture_stdout() as f:
+        muon.get_muon_and_adamw_params(muon_params=model.parameters())
+    if "Warning" not in f.getvalue():
+        print("Did not print warning when passing only muon_params")
+        return False
+
+    with capture_stdout() as f:
+        muon.get_muon_and_adamw_params(muon_params=model.parameters(), suppress_warning=True)
+    if f.getvalue().strip():
+        print("Warning was not suppressed when suppress_warning=True")
+        return False
+
+    return True
+
+def test_muon_step():
+    model = MLP(width=2).to("cuda")
+    try:
+        # Initialize for a single GPU
+        os.environ['MASTER_ADDR'] = 'localhost'
+        os.environ['MASTER_PORT'] = '12345'  # Any free port
+        dist.init_process_group(backend='nccl', rank=0, world_size=1)
+        optimizer = muon.Muon(params=model.parameters(), model=model, rank=0, world_size=1)
+    except Exception as e:
+        print(f"Muon optimizer failed to initialize: {e}")
+        return False
+    
+    # create data and simulate the forward pass
+    random_data = torch.randn(2, 2, device="cuda")
+    random_target = torch.randn(2, 2, device="cuda")
+    optimizer.zero_grad()
+    output = model.fc1(random_data)
+    output = model.relu(output)
+    output = model.fc2(output)
+    loss = F.mse_loss(output, random_target)
+    loss.backward()
+
+    # check that the optimizer step throws no errors
+    try:
+        optimizer.step()
+    except Exception as e:
+        print(f"Muon optimizer failed to step: {e}")
+        return False
+    
+    dist.destroy_process_group()
+    return True
+
+if __name__ == "__main__":
+    tests = [
+        test_mlp,
+        test_cnn,
+        test_gpt,
+        test_tied_embedding,
+        test_error_messages,
+        test_muon_step,
+    ]
+    for test in tests:
+        if not test():
+            print(f"^^^ {test.__name__} failed")
+            exit(1)
+    print("All tests passed!")


### PR DESCRIPTION
The motivation for this PR is to make it as easy as possible to use Muon:

`torch.optim.Adam(model.parameters())`

becomes

`Muon(model.parameters(), model=model)`

And if the user wants precise control they can still say `Muon(muon_params=params, adamw_params=other_params)`.

But by default, Muon auto-classifies parameters to be optimized with Muon or the internal AdamW. The reason `model` has to be passed is to check whether modules are subclasses of Linear, Conv1d, Conv2d, or Conv3d. These are the weight parameters that Muon is designed for. Passing the model isn't standard PyTorch philosophy, but Muon is an architecture-aware optimizer. The docstring links to the modular duality paper (the conference version of the anthology), which describes this point. Here's the main criterion:

```python
def muon_criterion(module, param):
    return (
        param.ndim > 1 and
        id(param) not in embedding_ids and  # prevents misclassifying tied embedding weights
        isinstance(module, (torch.nn.Linear, torch.nn.Conv1d, torch.nn.Conv2d, torch.nn.Conv3d))
    )
muon_param_ids = set()
for module in model.modules():
    for param in module.parameters(recurse=False):
        if muon_criterion(module, param):
            muon_param_ids.add(id(param))
```

I've added `test.py` with a lot of tests to make sure the interface is working as intended:
* test_mlp
* test_cnn
* test_gpt
* test_tied_embeddings
* test_error_messages
* test_muon_step

Not sure whether it's better to include `test.py` in the actual repository. I'd be happy to remove it. I'm also happy to iterate on any of the details in this PR. The goal is to make Muon so easy to use that it can't not catch on to be the most popular optimizer in the world.