### PR TITLE
skip params when grad is None

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 muon_optimizer.egg-info
 muon_optimizer.egg-info/*
+__pycache__/*
+__pycache__
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+muon_optimizer.egg-info
+muon_optimizer.egg-info/*

--- a/muon.py
+++ b/muon.py
@@ -82,6 +82,8 @@ class Muon(torch.optim.Optimizer):
             for base_i in range(len(params))[::dist.get_world_size()]:
                 if base_i + dist.get_rank() < len(params):
                     p = params[base_i + dist.get_rank()]
+                    if p.grad is None:
+                        continue
                     state = self.state[p]
                     if len(state) == 0:
                         state["momentum_buffer"] = torch.zeros_like(p)
@@ -111,6 +113,8 @@ class SingleDeviceMuon(torch.optim.Optimizer):
 
         for group in self.param_groups:
             for p in group["params"]:
+                if p.grad is None:
+                    continue
                 state = self.state[p]
                 if len(state) == 0:
                     state["momentum_buffer"] = torch.zeros_like(p)
@@ -190,6 +194,8 @@ class MuonWithAuxAdam(torch.optim.Optimizer):
                 for base_i in range(len(params))[::dist.get_world_size()]:
                     if base_i + dist.get_rank() < len(params):
                         p = params[base_i + dist.get_rank()]
+                        if p.grad is None:
+                            continue
                         state = self.state[p]
                         if len(state) == 0:
                             state["momentum_buffer"] = torch.zeros_like(p)
@@ -246,6 +252,8 @@ class SingleDeviceMuonWithAuxAdam(torch.optim.Optimizer):
         for group in self.param_groups:
             if group["use_muon"]:
                 for p in group["params"]:
+                    if p.grad is None:
+                        continue
                     state = self.state[p]
                     if len(state) == 0:
                         state["momentum_buffer"] = torch.zeros_like(p)


### PR DESCRIPTION
Not sure if anyone encounters this issue, but my program fails when some params don't have .grad yet. This is a simple fix to skip updating these params. The muon implementation in C-Optim also does a similar check:
[https://github.com/kyleliang919/C-Optim/blob/main/muon.py](url)
