### PR TITLE
Use Python 3.9 syntax and typing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,6 @@ setup(
         "Topic :: Scientific/Engineering :: Information Analysis",
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
This PR adds Python 3.9 typing to and formats muon.py. The purpose is to make it more like other PyTorch optimisers. 
While dropping the support of Python 3.7 and 3.8 may be a bad decision, it is a good first step to align with PyTorch 2.7. 