### PR TITLE
Asynchronous AllGather

### DIFF
--- a/muon.py
+++ b/muon.py
@@ -76,7 +76,7 @@ class Muon(torch.optim.Optimizer):
             with torch.enable_grad():
                 loss = closure()
 
-        handles = []
+        all_gather_futures = []
         for group in self.param_groups:
             params = group["params"]
             params_pad = params + [torch.empty_like(params[-1])] * (dist.get_world_size() - len(params) % dist.get_world_size())
@@ -92,11 +92,12 @@ class Muon(torch.optim.Optimizer):
                     update = muon_update(p.grad, state["momentum_buffer"], beta=group["momentum"])
                     p.mul_(1 - group["lr"] * group["weight_decay"])
                     p.add_(update.reshape(p.shape), alpha=-group["lr"])
-                handle = dist.all_gather(params_pad[base_i:base_i + dist.get_world_size()], params_pad[base_i + dist.get_rank()], async_op=True)
-                handles.append(handle)
+                future = dist.all_gather(params_pad[base_i:base_i + dist.get_world_size()], 
+                                         params_pad[base_i + dist.get_rank()], 
+                                         async_op=True).get_future()
+                all_gather_futures.append(future)
 
-        for handle in handles:
-            handle.wait()
+        torch.futures.wait_all(all_gather_futures)
 
         return loss
 

--- a/muon.py
+++ b/muon.py
@@ -92,7 +92,7 @@ class Muon(torch.optim.Optimizer):
                     update = muon_update(p.grad, state["momentum_buffer"], beta=group["momentum"])
                     p.mul_(1 - group["lr"] * group["weight_decay"])
                     p.add_(update.reshape(p.shape), alpha=-group["lr"])
-                handle = dist.all_gather(params_pad[base_i:base_i + dist.get_world_size()], params_pad[base_i + dist.get_rank()])
+                handle = dist.all_gather(params_pad[base_i:base_i + dist.get_world_size()], params_pad[base_i + dist.get_rank()], async_op=True)
                 handles.append(handle)
 
         for handle in handles:

--- a/muon.py
+++ b/muon.py
@@ -97,7 +97,7 @@ class Muon(torch.optim.Optimizer):
                                          async_op=True)
                 all_gather_futures.append(future)
 
-        for fut in gather_futures:
+        for fut in all_gather_futures:
               fut.wait()
 
         return loss

--- a/muon.py
+++ b/muon.py
@@ -94,10 +94,11 @@ class Muon(torch.optim.Optimizer):
                     p.add_(update.reshape(p.shape), alpha=-group["lr"])
                 future = dist.all_gather(params_pad[base_i:base_i + dist.get_world_size()], 
                                          params_pad[base_i + dist.get_rank()], 
-                                         async_op=True).get_future()
+                                         async_op=True)
                 all_gather_futures.append(future)
 
-        torch.futures.wait_all(all_gather_futures)
+        for fut in gather_futures:
+              fut.wait()
 
         return loss
 


### PR DESCRIPTION
Currently, all AllGather calls of the data-parallel Muon implementation are synchronous. This means that after orthogonalizing a gradient and updating its corresponding parameter, each GPU must wait for every other GPU to finish processing its parameter. We can make this faster by overlapping computation and communication, and just synchronizing at the end of the optimization step.

The modification is very simple. Replace this:
```python
for base_i in ...:
    dist.all_gather(...)
```
with:
```python
handles = []
for base_i in ...:
    handle = dist.all_gather(..., async_op=True)
    handles.append(handle)

for handle in handles:
    handle.wait()
```

### Speed-up
I tested this on a 1B transformer model trained on 8xA100-80GB with DDP and observed a 20% speed-up in the optimization step when using the **asynchronous** version. 

The speed-up will be even larger on models where the number of layers is not a multiple of the number of GPUs.